### PR TITLE
Modernize shell and Nuke snippets with safer defaults and compatibility notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,15 +48,26 @@ man cat
 #### chmod
 Used to change file permissions. Useful for limiting or sharing access to files.
 
+**Quick safety note:** prefer least-privilege permissions first, then relax only if needed.
+
 Set file to execute/read/write access to user only:
 ```commandline
 chmod 700 /path/to/file
 ```
 
-Set file to read/write access to read/write for everyone:
+Set file to read/write for user and group (safer team-share default):
+```commandline
+chmod 660 /path/to/file
+```
+
+Set file to read/write for everyone (rare; potentially risky):
 ```commandline
 chmod 666 /path/to/file
 ```
+
+When to use / when not to use:
+- Use `660` when files are shared inside a trusted group and other users should have no access.
+- Avoid `666` for scripts, configs, or production assets; world-writable files can be modified by any local user.
 
 To change all the directories to 755 (drwxr-xr-x):
 ```commandline
@@ -132,6 +143,8 @@ man find
 #### grep
 File pattern search tool.
 
+**Quick compatibility note:** `grep -r` works widely, but `rg` (ripgrep) is usually faster for large trees and respects ignore files.
+
 Find every line in a file that contains the text "file" in it:
 ```commandline
 grep 'file' /path/to/file.nk
@@ -139,13 +152,23 @@ grep 'file' /path/to/file.nk
 
 Find every line in every log file in a directory that contains the text "render" in it:
 ```commandline
-grep -r 'render' /path/to/files/*.log
+grep -r --include='*.log' 'render' /path/to/files/
 ```
 
 Find the path to every file that contains the text "compositing":
 ```commandline
-grep -rl 'compositing' /path/to/files/*.log
+grep -rl --include='*.log' 'compositing' /path/to/files/
 ```
+
+Equivalent with ripgrep (recommended for large projects):
+```commandline
+rg -n 'render' /path/to/files/
+rg -l 'compositing' /path/to/files/
+```
+
+When to use / when not to use:
+- Use recursive search on scoped paths (show/shot/task folders) to avoid accidental full-filesystem scans.
+- Avoid running broad recursive searches from `/` or very large mount points unless you intentionally need that scope.
 
 For more info:
 ```commandline
@@ -316,13 +339,13 @@ alias ls_all 'ls -l'
 Example of iterating through selected nodes
 ```python
 for n in nuke.selectedNodes():
-    print n.name()
+    print(n.name())
 ```
 
 Same example but only using a specific node class
 ```python
 for n in nuke.selectedNodes("Camera2"):
-    print n.name()
+    print(n.name())
 ```
 
 Get current script path
@@ -339,7 +362,7 @@ Looking through all nodes
 ```python
 for n in nuke.allNodes():
     if n.Class() == "Read":
-        print n.name()
+        print(n.name())
 ```
 
 Select a node by name
@@ -367,8 +390,12 @@ if knob.hasExpression():
 List all knobs on a node
 ```python
 for n in nuke.selectedNodes().knobs():
-    print n
+    print(n)
 ```
+
+When to use / when not to use:
+- Use `print(...)` syntax for Python 3 compatibility (current Nuke versions are Python 3-based).
+- Avoid Python 2 `print` statements (`print x`) unless maintaining legacy scripts on older Nuke/Python 2 environments.
 
 Set value on all Read nodes within a selected group
 ```python


### PR DESCRIPTION
### Motivation
- Improve safety and modern compatibility of examples in the documentation by replacing risky or legacy patterns with safer defaults and clearer guidance.
- Reduce accidental misuse of commands that can be dangerous at scale (world-writable permissions, broad recursive searches) and make Nuke snippets Python 3 friendly.

### Description
- Added a `Quick safety note` and a safer team-share example `chmod 660` to the `chmod` section, kept `chmod 666` but marked it as risky, and added a short "when to use / when not to use" caveat for permissions.
- Replaced broad `grep -r` examples with `grep -r --include='*.log'` scoped patterns, added `rg` (ripgrep) equivalents for large projects, and added a short scope/caution note for recursive searches.
- Updated Nuke Python examples to use `print(...)` for Python 3 compatibility and added a brief compatibility note advising when legacy Python 2 syntax might still be needed.
- Minor formatting and example adjustments to keep code blocks consistent and clearer in the `README.md` documentation.

### Testing
- Reviewed the updated `README.md` content and rendered code blocks to confirm examples are syntactically consistent and clear; this check passed.
- Performed repository diff and status checks to verify the documentation-only change is isolated to `README.md` and shows the expected insertions/deletions; these checks passed.
- No unit tests were required because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69881d241e648323b0c28120713c4711)